### PR TITLE
Fix table classes

### DIFF
--- a/netbox_data_flows/templates/netbox_data_flows/application.html
+++ b/netbox_data_flows/templates/netbox_data_flows/application.html
@@ -44,9 +44,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">Data Flow Groups</h5>
-        <div class="card-body table-responsive">
-          {% render_table dataflowgroups_table %}
-        </div>
+        {% render_table dataflowgroups_table %}
       </div>
     </div>
   </div>
@@ -55,9 +53,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">Data Flows</h5>
-        <div class="card-body table-responsive">
-          {% render_table dataflows_table %}
-        </div>
+        {% render_table dataflows_table %}
       </div>
     </div>
   </div>

--- a/netbox_data_flows/templates/netbox_data_flows/applicationrole.html
+++ b/netbox_data_flows/templates/netbox_data_flows/applicationrole.html
@@ -42,9 +42,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">Applications</h5>
-        <div class="card-body table-responsive">
-          {% render_table applications_table %}
-        </div>
+        {% render_table applications_table %}
       </div>
     </div>
   </div>

--- a/netbox_data_flows/templates/netbox_data_flows/dataflow.html
+++ b/netbox_data_flows/templates/netbox_data_flows/dataflow.html
@@ -96,9 +96,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">Children Data Flows</h5>
-        <div class="card-body table-responsive">
-          {% render_table children_table %}
-        </div>
+        {% render_table children_table %}
       </div>
     </div>
   </div>

--- a/netbox_data_flows/templates/netbox_data_flows/dataflow_tab.html
+++ b/netbox_data_flows/templates/netbox_data_flows/dataflow_tab.html
@@ -8,9 +8,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">Object Aliases</h5>
-        <div class="card-body table-responsive">
-          {% render_table aliases_table %}
-        </div>
+        {% render_table aliases_table %}
       </div>
     </div>
   </div>
@@ -19,9 +17,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">Source in Data Flows</h5>
-        <div class="card-body table-responsive">
-          {% render_table dataflow_sources_table %}
-        </div>
+        {% render_table dataflow_sources_table %}
       </div>
     </div>
   </div>
@@ -30,9 +26,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">Destination in Data Flows</h5>
-        <div class="card-body table-responsive">
-          {% render_table dataflow_destinations_table %}
-        </div>
+        {% render_table dataflow_destinations_table %}
       </div>
     </div>
   </div>

--- a/netbox_data_flows/templates/netbox_data_flows/dataflow_targets.html
+++ b/netbox_data_flows/templates/netbox_data_flows/dataflow_targets.html
@@ -40,9 +40,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">Sources</h5>
-        <div class="card-body table-responsive">
-          {% render_table sources_table %}
-        </div>
+        {% render_table sources_table %}
       </div>
     </div>
   </div>
@@ -51,9 +49,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">Destinations</h5>
-        <div class="card-body table-responsive">
-          {% render_table destinations_table %}
-        </div>
+        {% render_table destinations_table %}
       </div>
     </div>
   </div>

--- a/netbox_data_flows/templates/netbox_data_flows/dataflowgroup.html
+++ b/netbox_data_flows/templates/netbox_data_flows/dataflowgroup.html
@@ -71,9 +71,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">Data Flows (direct members)</h5>
-        <div class="card-body table-responsive">
-          {% render_table dataflows_table %}
-        </div>
+        {% render_table dataflows_table %}
       </div>
     </div>
   </div>
@@ -84,9 +82,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">Data Flows (child groups' members)</h5>
-        <div class="card-body table-responsive">
-          {% render_table dataflows_recursive_table %}
-        </div>
+        {% render_table dataflows_recursive_table %}
       </div>
     </div>
   </div>

--- a/netbox_data_flows/templates/netbox_data_flows/objectalias.html
+++ b/netbox_data_flows/templates/netbox_data_flows/objectalias.html
@@ -37,9 +37,7 @@
     <div class="col col-md-7">
       <div class="card">
         <h5 class="card-header">Member objects</h5>
-        <div class="card-body table-responsive">
-          {% render_table targets_table %}
-        </div>
+        {% render_table targets_table %}
       {% if perms.netbox_data_flows.change_objectalias %}
         <div class="card-footer text-end noprint">
           <a href="{% url 'plugins:netbox_data_flows:objectalias_addtarget' object.pk %}" class="btn btn-sm btn-primary">
@@ -56,9 +54,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">Source in Data Flows</h5>
-        <div class="card-body table-responsive">
-          {% render_table dataflow_sources_table %}
-        </div>
+        {% render_table dataflow_sources_table %}
       </div>
     </div>
   </div>
@@ -67,9 +63,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">Destination in Data Flows</h5>
-        <div class="card-body table-responsive">
-          {% render_table dataflow_destinations_table %}
-        </div>
+        {% render_table dataflow_destinations_table %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
According to the migration docs for NetBox 4 plugins, tables inside card bodies should not be enclosed by a card-body anymore.