### PR TITLE
Add a configuration option to collapse the menu under Plugins

### DIFF
--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -92,8 +92,25 @@ Deleting the data of the plugin is not recommended. If you really want to do it:
 
 ## Configuration
 
-There is no `PLUGIN_CONFIG` configuration for this plugin. However, several
-other aspects can be configured.
+The plugin can be configured in NetBox's `configuration.py` file.
+
+### Options
+
+You can configure the plugin by changing `PLUGIN_CONFIG`:
+
+```python
+# Add in: /opt/netbox/netbox/netbox/configuration.py
+
+PLUGINS_CONFIG = {
+    'netbox_data_flows': {
+        # Create a menu section for the plugin
+        'top_level_menu': True,
+    }
+}
+```
+
+Supported options:
+* `top_level_menu`: if set to `True` (default), the plugin will create its own menu section in the left navigation panel. If set to `False`, the plugin will be in a subsection under the `Plugins` section.
 
 ### Nomenclature
 

--- a/netbox_data_flows/__init__.py
+++ b/netbox_data_flows/__init__.py
@@ -14,7 +14,9 @@ class DataFlowsConfig(PluginConfig):
     base_url = "data-flows"
     author = "Thomas Fargeix"
     required_settings = []
-    default_settings = {}
+    default_settings = {
+        "top_level_menu": True,
+    }
     min_version = "4.0.0"
     max_version = "4.0.99"
 

--- a/netbox_data_flows/navigation.py
+++ b/netbox_data_flows/navigation.py
@@ -1,4 +1,5 @@
 from netbox.plugins import PluginMenu, PluginMenuButton, PluginMenuItem
+from netbox.plugins.utils import get_plugin_config
 
 
 #
@@ -6,6 +7,7 @@ from netbox.plugins import PluginMenu, PluginMenuButton, PluginMenuItem
 #
 
 APP_LABEL = "netbox_data_flows"
+top_level_menu = get_plugin_config("netbox_data_flows", "top_level_menu")
 
 
 # clone of netbox.navigation_menu.get_model_item, but for plugin
@@ -48,24 +50,39 @@ def get_model_buttons(model_name, actions=("add", "import")):
 # Nav menus
 #
 
-menu = PluginMenu(
-    label="Data Flows",
-    icon_class="mdi mdi-vector-polyline",
-    groups=(
-        (
-            "Applications",
+application_item = get_model_item("application", "Applications")
+applicationrole_item = get_model_item("applicationrole", "Application Roles")
+dataflow_item = get_model_item("dataflow", "Data Flows")
+dataflowgroup_item = get_model_item("dataflowgroup", "Data Flow Groups")
+objectalias_item = get_model_item("objectalias", "Object Aliases")
+
+if top_level_menu:
+    menu = PluginMenu(
+        label="Data Flows",
+        icon_class="mdi mdi-vector-polyline",
+        groups=(
             (
-                get_model_item("application", "Applications"),
-                get_model_item("applicationrole", "Application Roles"),
+                "Applications",
+                (
+                    application_item,
+                    applicationrole_item,
+                ),
+            ),
+            (
+                "Data Flows",
+                (
+                    dataflow_item,
+                    dataflowgroup_item,
+                    objectalias_item,
+                ),
             ),
         ),
-        (
-            "Data Flows",
-            (
-                get_model_item("dataflow", "Data Flows"),
-                get_model_item("dataflowgroup", "Data Flow Groups"),
-                get_model_item("objectalias", "Object Aliases"),
-            ),
-        ),
-    ),
-)
+    )
+else:
+    menu_items = [
+        application_item,
+        applicationrole_item,
+        dataflow_item,
+        dataflowgroup_item,
+        objectalias_item,
+    ]


### PR DESCRIPTION
Fixes #27

Add top_level_menu option (default to True). If set to False, the menu is collapsed under the Plugins section.