### PR TITLE
Fixes #32 - Placeholders are escaped when linkified

### DIFF
--- a/netbox_data_flows/templates/netbox_data_flows/application.html
+++ b/netbox_data_flows/templates/netbox_data_flows/application.html
@@ -23,7 +23,7 @@
           </tr>
           <tr>
             <th scope="row">{% trans "Role" %}</th>
-            <td>{{ object.role|placeholder|linkify }}</td>
+            <td>{{ object.role|linkify|placeholder }}</td>
           </tr>
           <tr>
             <th scope="row">{% trans "Description" %}</th>

--- a/netbox_data_flows/templates/netbox_data_flows/dataflow.html
+++ b/netbox_data_flows/templates/netbox_data_flows/dataflow.html
@@ -26,7 +26,7 @@
           <tr>
             <th scope="row">{% trans "Group" %}</th>
             <td>
-              {{ object.group|placeholder|linkify }}
+              {{ object.group|linkify|placeholder }}
             </td>
           </tr>
           <tr>

--- a/netbox_data_flows/templates/netbox_data_flows/dataflowgroup.html
+++ b/netbox_data_flows/templates/netbox_data_flows/dataflowgroup.html
@@ -26,7 +26,7 @@
           <tr>
             <th scope="row">{% trans "Parent" %}</th>
             <td>
-              {{ object.parent|placeholder|linkify }}
+              {{ object.parent|linkify|placeholder }}
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
Fixes #32 

Reorder the calls to placeholder and linkify in the templates to avoid escaping the placeholders.