### PR TITLE
Fix #39: Use default order for DFG in Application page

### DIFF
--- a/netbox_data_flows/views/applications.py
+++ b/netbox_data_flows/views/applications.py
@@ -42,11 +42,9 @@ class ApplicationView(generic.ObjectView):
                 "application",
                 "application__role",
                 "parent",
-            )
-            .annotate(
+            ).annotate(
                 dataflow_count=Count("dataflows", distinct=True),
             )
-            .order_by(*models.DataFlowGroup._meta.ordering)
         )
         dataflowgroups_table.configure(request)
 


### PR DESCRIPTION
Use the default ordering for NestedGroups as the TreeManager already handles ordering correctly even with annotate(). The forced ordering did not respect the group hierarchy.