### PR TITLE
Update when the CI runs the tests on new releases

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -7,15 +7,8 @@ permissions:
   contents: read
 
 jobs:
-  check-linting:
-    uses: ./.github/workflows/check-linting.yml
-
-  run-tests:
-    uses: ./.github/workflows/run-tests.yml
-
   build:
-    name: Check and build project
-    needs: [check-linting, run-tests]
+    name: Build project and check package
     runs-on: "ubuntu-latest"
 
     steps:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -9,12 +9,21 @@ permissions:
   contents: write
 
 jobs:
+  check-documentation:
+    uses: ./.github/workflows/check-documentation.yml
+
+  check-linting:
+    uses: ./.github/workflows/check-linting.yml
+
+  run-tests:
+    uses: ./.github/workflows/run-tests.yml
+
   build-package:
     uses: ./.github/workflows/build-package.yml
 
   autorelease:
     name: Create Draft Release
-    needs: [build-package]
+    needs: [check-documentation, check-linting, run-tests, build-package]
     runs-on: "ubuntu-latest"
 
     steps:


### PR DESCRIPTION
Run test when creating release, not when publishing. Avoid running the tests several times on the same tag.