### PR TITLE
Dev/inherited tags

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -79,6 +79,8 @@ By convention, if the list of source ports or destination ports is empty, this m
 
 **Data Flow Groups** form a forest of groups. They can also be assigned to an Application. Data Flow Groups can be enabled and disabled and inherit the status of their parent. Disabled Data Flow Groups disable all the Data Flows contained within.
 
+Only in the REST API, the inherited list of tags is available (inherited_tags when reading and inherited_tag when filtering). This is the set of tags of the data flow and its parent groups. This field is not displyed in the UI.
+
 ### Object Alias
 
 **Object Aliases** are a group of references to other NetBox objects. Object Aliases are used as sources and destinations of Data Flows and corresponds to the groups or aliases used in firewall configuration.

--- a/netbox_data_flows/api/serializers/dataflows.py
+++ b/netbox_data_flows/api/serializers/dataflows.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
 from netbox.api.fields import ChoiceField, SerializedPKRelatedField
-from netbox.api.serializers import NetBoxModelSerializer
+from netbox.api.serializers import NestedTagSerializer, NetBoxModelSerializer
 
 from tenancy.api.serializers import TenantSerializer
 
@@ -45,6 +45,8 @@ class DataFlowSerializer(NetBoxModelSerializer):
         many=True,
     )
 
+    inherited_tags = NestedTagSerializer(many=True, required=False, read_only=True)
+
     class Meta:
         model = models.DataFlow
         fields = (
@@ -67,6 +69,7 @@ class DataFlowSerializer(NetBoxModelSerializer):
             "sources",
             "status",
             "tags",
+            "inherited_tags",
             "url",
         )
         brief_fields = (

--- a/netbox_data_flows/api/serializers/groups.py
+++ b/netbox_data_flows/api/serializers/groups.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
 from netbox.api.fields import ChoiceField
-from netbox.api.serializers import NetBoxModelSerializer, WritableNestedSerializer
+from netbox.api.serializers import NestedTagSerializer, NetBoxModelSerializer, WritableNestedSerializer
 
 from tenancy.api.serializers import TenantSerializer
 
@@ -60,6 +60,8 @@ class DataFlowGroupSerializer(NetBoxModelSerializer):
     _depth = serializers.IntegerField(source="level", read_only=True)
     tenant = TenantSerializer(nested=True, required=False, allow_null=True, default=None)
 
+    inherited_tags = NestedTagSerializer(many=True, required=False, read_only=True)
+
     class Meta:
         model = models.DataFlowGroup
         fields = (
@@ -78,6 +80,7 @@ class DataFlowGroupSerializer(NetBoxModelSerializer):
             "tenant",
             "slug",
             "status",
+            "inherited_tags",
             "tags",
             "url",
         )

--- a/netbox_data_flows/models/dataflows.py
+++ b/netbox_data_flows/models/dataflows.py
@@ -4,6 +4,7 @@ from django.db import models
 from django.urls import reverse
 from django.utils.functional import cached_property
 
+from extras.models import Tag
 from netbox.models import NetBoxModel
 from utilities.data import array_to_string
 from utilities.querysets import RestrictedQuerySet
@@ -108,6 +109,18 @@ class DataFlow(NetBoxModel):
 
     def get_status_color(self):
         return DataFlowInheritedStatusChoices.colors.get(self.inherited_status)
+
+    @property
+    def inherited_tags(self):
+        if not self.pk:
+            return []
+
+        if not self.group:
+            return self.tags.all()
+
+        return Tag.objects.filter(
+            models.Q(dataflow=self.pk) | models.Q(dataflowgroup__in=self.group.get_ancestors(include_self=True))
+        ).distinct()
 
     #
     # Specification

--- a/netbox_data_flows/models/groups.py
+++ b/netbox_data_flows/models/groups.py
@@ -3,6 +3,7 @@ from django.db import models
 from django.urls import reverse
 from django.utils.functional import cached_property
 
+from extras.models import Tag
 from netbox.models import NestedGroupModel
 from utilities.mptt import TreeManager, TreeQuerySet
 
@@ -76,6 +77,13 @@ class DataFlowGroup(NestedGroupModel):
 
     def get_status_color(self):
         return DataFlowInheritedStatusChoices.colors.get(self.inherited_status)
+
+    @property
+    def inherited_tags(self):
+        if not self.pk:
+            return []
+
+        return Tag.objects.filter(dataflowgroup__in=self.get_ancestors(include_self=True)).distinct()
 
     class Meta:
         ordering = (

--- a/netbox_data_flows/tests/data.py
+++ b/netbox_data_flows/tests/data.py
@@ -1,3 +1,5 @@
+from utilities.testing import create_tags
+
 from dcim import models as dcim
 from ipam import models as ipam
 from virtualization import models as virtualization
@@ -15,6 +17,14 @@ class TestData:
     _prefixes = None
     _ranges = None
     _ips = None
+
+    _tags = None
+
+    def get_tags(self):
+        if not self._tags:
+            self._tags = tuple(create_tags("tag0", "tag1", "tag2", "tag3", "tag4", "tag5", "tag6"))
+
+        return self._tags
 
     def get_applicationroles(self):
         if not self._applicationsroles:
@@ -60,102 +70,148 @@ class TestData:
     def get_dataflowgroups(self):
         if not self._dataflowgroups:
             apps = self.get_applications()
+            tags = self.get_tags()
 
             group1 = models.DataFlowGroup(
+                # pk = 0
                 application=None,
                 parent=None,
                 name="Group 1",
                 slug="group-1",
                 description="foobar1",
                 status=choices.DataFlowStatusChoices.STATUS_ENABLED,
+                # inherited status = enabled
+                # tags = [0,1]
+                # inherited tags = [0,1]
             )
             group11 = models.DataFlowGroup(
+                # pk = 1
                 application=apps[0],
                 parent=group1,
                 name="Group 1.1",
                 slug="group-1-1",
                 description="foobar11",
                 status=choices.DataFlowStatusChoices.STATUS_DISABLED,
+                # inherited status = disabled
+                # tags = [1]
+                # inherited tags = [0,1]
             )
             group111 = models.DataFlowGroup(
+                # pk = 2
                 application=apps[0],
                 parent=group11,
                 name="Group 1.1.1",
                 slug="group-1-1-1",
                 description="foobar111",
                 status=choices.DataFlowStatusChoices.STATUS_ENABLED,
+                # inherited status = disabled
+                # tags = [3]
+                # inherited tags = [0,1,3]
             )
             group112 = models.DataFlowGroup(
+                # pk = 3
                 application=apps[1],
                 parent=group11,
                 name="Group 1.1.2",
                 slug="group-1-1-2",
                 description="foobar112",
                 status=choices.DataFlowStatusChoices.STATUS_DISABLED,
+                # inherited status = disabled
+                # tags = [2]
+                # inherited tags = [0,1,2]
             )
             group113 = models.DataFlowGroup(
+                # pk = 4
                 application=apps[0],
                 parent=group11,
                 name="Group 1.1.3",
                 slug="group-1-1-3",
                 description="foobar113",
                 status=choices.DataFlowStatusChoices.STATUS_ENABLED,
+                # inherited status = disabled
+                # tags = []
+                # inherited tags = [0,1]
             )
             group12 = models.DataFlowGroup(
+                # pk = 5
                 application=apps[2],
                 parent=group1,
                 name="Group 1.2",
                 slug="group-1-2",
                 description="foobar12",
                 status=choices.DataFlowStatusChoices.STATUS_ENABLED,
+                # inherited status = enabled
+                # tags = []
+                # inherited tags = [0,1]
             )
             group121 = models.DataFlowGroup(
+                # pk = 6
                 application=None,
                 parent=group12,
                 name="Group 1.2.1",
                 slug="group-1-2-1",
                 description="foobar121",
                 status=choices.DataFlowStatusChoices.STATUS_ENABLED,
+                # inherited status = enabled
+                # tags = []
+                # inherited tags = [0,1]
             )
             group122 = models.DataFlowGroup(
+                # pk = 7
                 application=apps[3],
                 parent=group12,
                 name="Group 1.2.2",
                 slug="group-1-2-2",
                 description="foobar122",
                 status=choices.DataFlowStatusChoices.STATUS_DISABLED,
+                # inherited status = disabled
+                # tags = []
+                # inherited tags = [0,1]
             )
             group2 = models.DataFlowGroup(
+                # pk = 8
                 application=apps[4],
                 parent=None,
                 name="Group 2",
                 slug="group-2",
                 description="foobar2",
                 status=choices.DataFlowStatusChoices.STATUS_ENABLED,
+                # inherited status = enabled
+                # tags = []
+                # inherited tags = []
             )
             group3 = models.DataFlowGroup(
+                # pk = 9
                 application=None,
                 parent=None,
                 name="Group 3",
                 slug="group-3",
                 description="foobar3",
                 status=choices.DataFlowStatusChoices.STATUS_ENABLED,
+                # inherited status = enabled
+                # tags = []
+                # inherited tags = []
             )
 
             self._dataflowgroups = (
-                group1,
-                group11,
-                group111,
-                group112,
-                group113,
-                group12,
-                group121,
-                group122,
-                group2,
-                group3,
+                group1,  # pk = 0
+                group11,  # pk = 1
+                group111,  # pk = 2
+                group112,  # pk = 3
+                group113,  # pk = 4
+                group12,  # pk = 5
+                group121,  # pk = 6
+                group122,  # pk = 7
+                group2,  # pk = 8
+                group3,  # pk = 9
             )
             for obj in self._dataflowgroups:
                 obj.save()
+
+            group1.tags.set(tags[0:2])
+            group11.tags.set(tags[1:2])
+            group111.tags.set(tags[3:4])
+            group112.tags.set(tags[2:3])
 
         return self._dataflowgroups
 
@@ -360,6 +416,7 @@ class TestData:
             apps = self.get_applications()
             groups = self.get_dataflowgroups()
             aliases = self.get_objectaliases()
+            tags = self.get_tags()
 
             self._dataflows = []
             self._dataflows += [
@@ -372,8 +429,11 @@ class TestData:
                     protocol=choices.DataFlowProtocolChoices.PROTOCOL_ANY,
                     source_ports=None,
                     destination_ports=None,
+                    # inherited status = disabled
+                    # inherited tags = []
                 )
             ]
+
             self._dataflows += [
                 models.DataFlow.objects.create(
                     name="Data Flow 2",
@@ -384,8 +444,12 @@ class TestData:
                     protocol=choices.DataFlowProtocolChoices.PROTOCOL_ICMP,
                     source_ports=None,
                     destination_ports=None,
+                    # inherited status = enabled
+                    # inherited tags = [6]
                 )
             ]
+            self._dataflows[-1].tags.set(tags[6:7])
+
             self._dataflows += [
                 models.DataFlow.objects.create(
                     name="Data Flow 3",
@@ -396,8 +460,11 @@ class TestData:
                     protocol=choices.DataFlowProtocolChoices.PROTOCOL_TCP,
                     source_ports=None,
                     destination_ports=[80],
+                    # inherited status = disabled
+                    # inherited tags = [0,1,3,4,5]
                 )
             ]
+            self._dataflows[-1].tags.set(tags[4:6])
             self._dataflows[-1].sources.set([aliases[0]])
             self._dataflows[-1].destinations.set([aliases[1]])
 
@@ -411,6 +478,8 @@ class TestData:
                     protocol=choices.DataFlowProtocolChoices.PROTOCOL_TCP,
                     source_ports=None,
                     destination_ports=[81, 82],
+                    # inherited status = enabled
+                    # inherited tags = [0,1]
                 )
             ]
             self._dataflows[-1].sources.set([aliases[0]])
@@ -429,6 +498,8 @@ class TestData:
                     protocol=choices.DataFlowProtocolChoices.PROTOCOL_UDP,
                     source_ports=[55, 57],
                     destination_ports=[81, 82],
+                    # inherited status = disabled
+                    # inherited tags = [0,1]
                 )
             ]
             self._dataflows[-1].sources.set([aliases[1], aliases[2]])
@@ -444,6 +515,8 @@ class TestData:
                     protocol=choices.DataFlowProtocolChoices.PROTOCOL_TCP_UDP,
                     source_ports=None,
                     destination_ports=[100],
+                    # inherited status = enabled
+                    # inherited tags = [0,1]
                 )
             ]
             self._dataflows[-1].destinations.set([aliases[3], aliases[4]])
@@ -458,6 +531,8 @@ class TestData:
                     protocol=choices.DataFlowProtocolChoices.PROTOCOL_SCTP,
                     source_ports=[200],
                     destination_ports=[200],
+                    # inherited status = enabled
+                    # inherited tags = [0,1]
                 )
             ]
             self._dataflows[-1].sources.set([aliases[4]])
@@ -472,6 +547,8 @@ class TestData:
                     protocol=choices.DataFlowProtocolChoices.PROTOCOL_TCP,
                     source_ports=[400],
                     destination_ports=[400],
+                    # inherited status = enabled
+                    # inherited tags = []
                 )
             ]
             self._dataflows[-1].sources.set([aliases[5]])

--- a/netbox_data_flows/tests/test_filtersets.py
+++ b/netbox_data_flows/tests/test_filtersets.py
@@ -78,6 +78,7 @@ class DataFlowGroupTestCase(TestCase):
     def setUpTestData(cls):
         data = TestData()
         data.get_dataflowgroups()
+        cls.tags = data.get_tags()
 
     def test_q(self):
         params = {"q": "FOObar2"}
@@ -110,6 +111,17 @@ class DataFlowGroupTestCase(TestCase):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 5)
         params = {"inherited_status": choices.DataFlowStatusChoices.STATUS_DISABLED}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 5)
+
+    def test_inherited_tags(self):
+        tags = self.tags
+        params = {"inherited_tag": [tags[1]]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 8)
+        params = {"inherited_tag": [tags[2]]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"inherited_tag": [tags[0], tags[3]]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"inherited_tag": [tags[0], tags[5]]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 0)
 
     def test_parent(self):
         groups = self.queryset.all()[:3]
@@ -271,6 +283,7 @@ class DataFlowTestCase(TestCase):
     def setUpTestData(cls):
         data = TestData()
         data.get_dataflows()
+        cls.tags = data.get_tags()
 
     def test_q(self):
         params = {"q": "DATA FLOW 1"}
@@ -297,6 +310,19 @@ class DataFlowTestCase(TestCase):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 5)
         params = {"inherited_status": choices.DataFlowStatusChoices.STATUS_DISABLED}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
+
+    def test_inherited_tags(self):
+        tags = self.tags
+        params = {"inherited_tag": [tags[1]]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 5)
+        params = {"inherited_tag": [tags[2]]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 0)
+        params = {"inherited_tag": [tags[0], tags[3]]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"inherited_tag": [tags[0], tags[5]]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {"inherited_tag": [tags[6]]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_application(self):
         applications = models.Application.objects.all()[:2]

--- a/netbox_data_flows/tests/test_models.py
+++ b/netbox_data_flows/tests/test_models.py
@@ -48,6 +48,7 @@ class DataFlowTestCase(TestCase):
     def setUpTestData(cls):
         data = TestData()
         cls.dataflows = data.get_dataflows()
+        cls.tags = data.get_tags()
 
     def test_qs_only_disabled(self):
         qs = self.model.objects.only_disabled()
@@ -194,6 +195,21 @@ class DataFlowTestCase(TestCase):
             choices.DataFlowInheritedStatusChoices.STATUS_DISABLED,
         )
 
+    def test_inherited_tags(self):
+        dataflows = self.dataflows
+        tags = self.tags
+
+        self.assertEqual(set(dataflows[0].inherited_tags), set())
+        self.assertEqual(set(dataflows[1].inherited_tags), set(tags[6:7]))
+
+        self.assertEqual(len(dataflows[2].inherited_tags), 5)
+        self.assertEqual(set(dataflows[2].inherited_tags), set(tags[0:2]) | set(tags[3:6]))
+
+        for i in [3, 4, 5, 6]:
+            self.assertEqual(set(dataflows[i].inherited_tags), set(tags[0:2]))
+
+        self.assertEqual(set(dataflows[7].inherited_tags), set())
+
 
 class DataFlowGroupTestCase(TestCase):
     model = models.DataFlowGroup
@@ -201,7 +217,8 @@ class DataFlowGroupTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
         data = TestData()
-        data.get_dataflowgroups()
+        cls.groups = data.get_dataflowgroups()
+        cls.tags = data.get_tags()
 
     def test_qs_only_disabled(self):
         qs = self.model.objects.only_disabled()
@@ -214,7 +231,8 @@ class DataFlowGroupTestCase(TestCase):
         self.assertEqual(qs.count(), 5)
 
     def test_inherited_status(self):
-        groups = self.model.objects.all()
+        groups = self.groups
+
         self.assertEqual(
             groups[1].inherited_status,
             choices.DataFlowInheritedStatusChoices.STATUS_DISABLED,
@@ -235,3 +253,21 @@ class DataFlowGroupTestCase(TestCase):
             groups[7].inherited_status,
             choices.DataFlowInheritedStatusChoices.STATUS_DISABLED,
         )
+
+    def test_inherited_tags(self):
+        groups = self.groups
+        tags = self.tags
+
+        self.assertEqual(set(groups[0].inherited_tags), set(tags[0:2]))
+        self.assertEqual(set(groups[1].inherited_tags), set(tags[0:2]))
+
+        self.assertEqual(len(groups[2].inherited_tags), 3)
+        self.assertEqual(set(groups[2].inherited_tags), set(tags[0:2]) | set(tags[3:4]))
+
+        self.assertEqual(set(groups[3].inherited_tags), set(tags[0:3]))
+
+        for i in [4, 5, 6, 7]:
+            self.assertEqual(set(groups[i].inherited_tags), set(tags[0:2]))
+
+        self.assertEqual(set(groups[8].inherited_tags), set())
+        self.assertEqual(set(groups[9].inherited_tags), set())


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox Data Flow!

    Please DO NOT create a public pull request for SECURITY issue. Report them
    via the security advisories:
    https://github.com/Alef-Burzmali/netbox-data-flows/security/advisories/new

    Pull requests are welcome, but if it changes models or add a non-trivial
    feature, please create an issue first to discuss and agree on an approach
    to avoid wasting your time and effort on a proposed change that we might
    not be able to accept.
-->
### Fixes: #62 
Implement an inherited_tags field in REST API for DataFlow and DataFlowGroup. This read-only field contains the set of all parent groups' tags and the dataflow's tags.

The field can be filtered on via inherited_tag and inherited_tag_id
