### PR TITLE
Fix tests for NetBox 4.4.0

### DIFF
--- a/netbox_data_flows/tests/test_views.py
+++ b/netbox_data_flows/tests/test_views.py
@@ -160,15 +160,16 @@ class DataFlowGroupTestCase(PluginUrlBase, ViewTestCases.OrganizationalObjectVie
         }
 
     def test_delete_object_with_constrained_permission(self):
-        # Remove all parents to avoid deletion cascade that would
-        # fail the test
-
-        groups = models.DataFlowGroup.objects.all()
-        for obj in groups:
-            obj.parent = None
-            obj.save()
+        # Remove all parents to avoid deletion cascade that would fail the test
+        models.DataFlowGroup.objects.all().update(parent=None)
 
         super().test_delete_object_with_constrained_permission()
+
+    def test_bulk_delete_objects_with_permission(self):
+        # Remove all parents to avoid deletion cascade that would fail the test
+        models.DataFlowGroup.objects.all().update(parent=None)
+
+        super().test_bulk_delete_objects_with_permission()
 
 
 class DataFlowTestCase(PluginUrlBase, ViewTestCases.PrimaryObjectViewTestCase):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox Data Flow!

    Please DO NOT create a public pull request for SECURITY issue. Report them
    via the security advisories:
    https://github.com/Alef-Burzmali/netbox-data-flows/security/advisories/new

    Pull requests are welcome, but if it changes models or add a non-trivial
    feature, please create an issue first to discuss and agree on an approach
    to avoid wasting your time and effort on a proposed change that we might
    not be able to accept.
-->
### Fixes: #80 

test_views.DataFlowGroupTestCase.test_bulk_delete_objects_with_permission was failing because of the cascade deletion triggered when bulk deleting groups with subgroups.

This creating multiple changelogs, failing the test checking for a specific changelog message.

<!--
    Please include a summary of the proposed changes below.
-->
