### PR TITLE
Use HTMX table inclusions to simplify views when possible

### DIFF
--- a/netbox_data_flows/filtersets/dataflows.py
+++ b/netbox_data_flows/filtersets/dataflows.py
@@ -51,6 +51,17 @@ class DataFlowFilterSet(
         label="Group, recursive membership (slug)",
         method="filter_recursive_groups",
     )
+    ancestor_group_id = ModelMultipleChoiceFilter(
+        queryset=models.DataFlowGroup.objects.all(),
+        label="Group, recursive membership excluding direct parent (ID)",
+        method="filter_recursive_groups",
+    )
+    ancestor_recursive_group = ModelMultipleChoiceFilter(
+        queryset=models.DataFlowGroup.objects.all(),
+        to_field_name="slug",
+        label="Group, recursive membership excluding direct parent (slug)",
+        method="filter_recursive_groups",
+    )
 
     protocol = MultipleChoiceFilter(
         choices=choices.DataFlowProtocolChoices,
@@ -155,7 +166,8 @@ class DataFlowFilterSet(
         if not value:
             return queryset
 
-        return queryset.part_of_group_recursive(*value)
+        include_self = field_name.startswith("recursive")
+        return queryset.part_of_group_recursive(*value, include_direct_children=include_self)
 
     def filter_inherited_tags(self, queryset, name, value):
         if not value:

--- a/netbox_data_flows/templates/netbox_data_flows/application.html
+++ b/netbox_data_flows/templates/netbox_data_flows/application.html
@@ -4,7 +4,6 @@
 {% load i18n %}
 {% load perms %}
 {% load plugins %}
-{% load render_table from django_tables2 %}
 
 {% block breadcrumbs %}
   {{ block.super }}
@@ -57,7 +56,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">{% trans "Data Flow Groups" %}</h5>
-        {% render_table dataflowgroups_table %}
+        {% htmx_table 'plugins:netbox_data_flows:dataflowgroup_list' application_id=object.id %}
       </div>
     </div>
   </div>
@@ -66,7 +65,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">{% trans "Data Flows" %}</h5>
-        {% render_table dataflows_table %}
+        {% htmx_table 'plugins:netbox_data_flows:dataflow_list' application_id=object.id %}
       </div>
     </div>
   </div>

--- a/netbox_data_flows/templates/netbox_data_flows/applicationrole.html
+++ b/netbox_data_flows/templates/netbox_data_flows/applicationrole.html
@@ -4,7 +4,6 @@
 {% load i18n %}
 {% load perms %}
 {% load plugins %}
-{% load render_table from django_tables2 %}
 
 {% block content %}
   <div class="row">
@@ -43,7 +42,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">{% trans "Applications" %}</h5>
-        {% render_table applications_table %}
+        {% htmx_table 'plugins:netbox_data_flows:application_list' role_id=object.id %}
       </div>
     </div>
   </div>

--- a/netbox_data_flows/templates/netbox_data_flows/dataflowgroup.html
+++ b/netbox_data_flows/templates/netbox_data_flows/dataflowgroup.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object.html' %}
+g{% extends 'generic/object.html' %}
 {% load buttons %}
 {% load helpers %}
 {% load i18n %}
@@ -15,7 +15,7 @@
 
 {% block content %}
   <div class="row">
-    <div class="col col-md-6">
+    <div class="col col-md-5">
       <div class="card">
         <h5 class="card-header">{% trans "Data Flow Group" %}</h5>
         <table class="table table-hover attr-table">
@@ -65,11 +65,11 @@
       {% include 'inc/panels/custom_fields.html' %}
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-md-7">
       <div class="card">
         <h5 class="card-header">{% trans "Child Groups" %}</h5>
         <div class="card-body table-responsive">
-          {% render_table children_table %}
+          {% htmx_table 'plugins:netbox_data_flows:dataflowgroup_list' parent_id=object.id %}
         </div>
       </div>
       {% plugin_right_page object %}
@@ -80,7 +80,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">{% trans "Data Flows (direct members)" %}</h5>
-        {% render_table dataflows_table %}
+        {% htmx_table 'plugins:netbox_data_flows:dataflow_list' group_id=object.id %}
       </div>
     </div>
   </div>
@@ -89,7 +89,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">{% trans "Data Flows (child groups' members)" %}</h5>
-        {% render_table dataflows_recursive_table %}
+        {% htmx_table 'plugins:netbox_data_flows:dataflow_list' ancestor_group_id=object.id %}
       </div>
     </div>
   </div>

--- a/netbox_data_flows/templates/netbox_data_flows/objectalias.html
+++ b/netbox_data_flows/templates/netbox_data_flows/objectalias.html
@@ -76,7 +76,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">{% trans "Source in Data Flows" %}</h5>
-        {% render_table dataflow_sources_table %}
+        {% htmx_table 'plugins:netbox_data_flows:dataflow_list' source_aliases=object.id %}
       </div>
     </div>
   </div>
@@ -85,7 +85,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">{% trans "Destination in Data Flows" %}</h5>
-        {% render_table dataflow_destinations_table %}
+        {% htmx_table 'plugins:netbox_data_flows:dataflow_list' destination_aliases=object.id %}
       </div>
     </div>
   </div>

--- a/netbox_data_flows/views/applicationroles.py
+++ b/netbox_data_flows/views/applicationroles.py
@@ -30,18 +30,6 @@ class ApplicationRoleListView(generic.ObjectListView):
 class ApplicationRoleView(generic.ObjectView):
     queryset = models.ApplicationRole.objects.all()
 
-    def get_extra_context(self, request, instance):
-        applications_table = tables.ApplicationTable(
-            instance.applications.prefetch_related("role").annotate(
-                dataflow_count=Count("dataflows", distinct=True),
-            )
-        )
-        applications_table.configure(request)
-
-        return {
-            "applications_table": applications_table,
-        }
-
 
 @register_model_view(models.ApplicationRole, "add", detail=False)
 @register_model_view(models.ApplicationRole, "edit")

--- a/netbox_data_flows/views/applications.py
+++ b/netbox_data_flows/views/applications.py
@@ -43,20 +43,8 @@ class ApplicationView(GetRelatedCustomFieldModelsMixin, generic.ObjectView):
     def get_extra_context(self, request, instance):
         related_models = self.get_related_models(request, instance)
 
-        dataflowgroups_table = tables.DataFlowGroupTable(
-            instance.dataflow_groups.annotate(
-                dataflow_count=Count("dataflows", distinct=True),
-            )
-        )
-        dataflowgroups_table.configure(request)
-
-        dataflows_table = tables.DataFlowTable(instance.dataflows.all())
-        dataflows_table.configure(request)
-
         return {
             "related_models": related_models,
-            "dataflowgroups_table": dataflowgroups_table,
-            "dataflows_table": dataflows_table,
         }
 
 

--- a/netbox_data_flows/views/groups.py
+++ b/netbox_data_flows/views/groups.py
@@ -31,53 +31,11 @@ class DataFlowGroupListView(generic.ObjectListView):
 class DataFlowGroupView(generic.ObjectView):
     queryset = models.DataFlowGroup.objects.all()
 
-    def get_extra_context(self, request, instance):
-        children_table = tables.DataFlowGroupTable(
-            instance.get_descendants(include_self=False).annotate(
-                dataflow_count=Count("dataflows", distinct=True),
-            )
-        )
-        children_table.configure(request)
-
-        # our direct dataflows
-        dataflows_table = tables.DataFlowTable(
-            instance.dataflows.prefetch_related(
-                "application",
-                "application__role",
-                "group",
-                "sources",
-                "destinations",
-            )
-        )
-        dataflows_table.configure(request)
-
-        # dataflows of our descendants
-        dataflows_recursive_table = tables.DataFlowTable(
-            models.DataFlow.objects.part_of_group_recursive(instance, include_direct_children=False).prefetch_related(
-                "application",
-                "application__role",
-                "group",
-                "sources",
-                "destinations",
-            )
-        )
-        dataflows_recursive_table.configure(request)
-
-        return {
-            "children_table": children_table,
-            "dataflows_table": dataflows_table,
-            "dataflows_recursive_table": dataflows_recursive_table,
-        }
-
 
 @register_model_view(models.DataFlowGroup, "add", detail=False)
 @register_model_view(models.DataFlowGroup, "edit")
 class DataFlowGroupEditView(generic.ObjectEditView):
-    queryset = models.DataFlowGroup.objects.prefetch_related(
-        "application",
-        "application__role",
-        "parent",
-    )
+    queryset = models.DataFlowGroup.objects.all()
     form = forms.DataFlowGroupForm
 
 
@@ -95,11 +53,7 @@ class DataFlowGroupBulkImportView(generic.BulkImportView):
 
 @register_model_view(models.DataFlowGroup, "bulk_edit", path="edit", detail=False)
 class DataFlowGroupBulkEditView(generic.BulkEditView):
-    queryset = models.DataFlowGroup.objects.prefetch_related(
-        "application",
-        "application__role",
-        "parent",
-    ).annotate(
+    queryset = models.DataFlowGroup.objects.annotate(
         dataflow_count=Count("dataflows", distinct=True),
     )
     filterset = filtersets.DataFlowGroupFilterSet
@@ -109,11 +63,7 @@ class DataFlowGroupBulkEditView(generic.BulkEditView):
 
 @register_model_view(models.DataFlowGroup, "bulk_delete", path="delete", detail=False)
 class DataFlowGroupBulkDeleteView(generic.BulkDeleteView):
-    queryset = models.DataFlowGroup.objects.prefetch_related(
-        "application",
-        "application__role",
-        "parent",
-    ).annotate(
+    queryset = models.DataFlowGroup.objects.annotate(
         dataflow_count=Count("dataflows", distinct=True),
     )
     filterset = filtersets.DataFlowGroupFilterSet


### PR DESCRIPTION
Replace tables in templates and views of:
* Application roles
* Applications
* Data Flow Groups
* Object Aliases (only the data flow tables)

Add a filterset to select dataflows in children of a group, excluding the group itself.

These tables cannot be replaced yet:
* Tab views of assets linked to a object alias / data flow: the htmx_table tag does not send the model of the object to the filterset
* Prefix, IP Range and IP Address tables of an object alias or a dataflow: their filterset cannot filter on object aliases or data flows