### PR TITLE
Add 'Related Data Flows' tab

### DIFF
--- a/netbox_data_flows/models/dataflows.py
+++ b/netbox_data_flows/models/dataflows.py
@@ -50,6 +50,18 @@ class DataFlowQuerySet(RestrictedQuerySet):
     def destinations(self, *objects):
         return self.filter(models.Q(destinations__in=ObjectAlias.objects.contains(*objects))).distinct()
 
+    def related_sources_or_destinations(self, *objects):
+        return self.filter(
+            models.Q(sources__in=ObjectAlias.objects.related_to(*objects))
+            | models.Q(destinations__in=ObjectAlias.objects.related_to(*objects))
+        ).distinct()
+
+    def related_sources(self, *objects):
+        return self.filter(models.Q(sources__in=ObjectAlias.objects.related_to(*objects))).distinct()
+
+    def related_destinations(self, *objects):
+        return self.filter(models.Q(destinations__in=ObjectAlias.objects.related_to(*objects))).distinct()
+
 
 class DataFlow(PrimaryModel):
     """Representation of a data flow for an application."""

--- a/netbox_data_flows/models/objectaliases.py
+++ b/netbox_data_flows/models/objectaliases.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.urls import reverse
 
+from netaddr.ip import IPNetwork
 from netbox.models import PrimaryModel
 from utilities.querysets import RestrictedQuerySet
 
@@ -29,6 +30,48 @@ class ObjectAliasQuerySet(RestrictedQuerySet):
                     raise TypeError(f"Cannot test if {self.__class__} contains {obj}") from e
 
             filtering |= models.Q(ip_addresses__in=dev_addresses)
+
+        return self.filter(filtering).distinct()
+
+    def related_to(self, *objects):
+        """Return ObjectAlias related to any one of the objects in parameter."""
+        filtering = models.Q()
+        if prefixes := [o for o in objects if o._meta.model_name == "prefix"]:
+            for prefix in prefixes:
+                network_address = IPNetwork(f"{prefix.prefix.network}/{prefix.prefix.prefixlen}")
+                broadcast_address = IPNetwork(f"{prefix.prefix.broadcast}/{prefix.prefix.prefixlen}")
+
+                # prefixes where passed prefix is within prefix
+                filtering |= models.Q(prefixes__vrf=prefix.vrf, prefixes__prefix__net_contains=prefix.prefix)
+                # ranges where passed prefix is within or equals range
+                filtering |= models.Q(ip_ranges__vrf=prefix.vrf, ip_ranges__start_address__lte=network_address, ip_ranges__end_address__gte=broadcast_address)
+        if ip_ranges := [o for o in objects if o._meta.model_name == "iprange"]:
+            for ip_range in ip_ranges:
+                # prefixes where passed range is within or equals prefix
+                filtering |= (
+                    models.Q(prefixes__vrf=ip_range.vrf, prefixes__prefix__net_contains_or_equals=ip_range.start_address) &
+                    models.Q(prefixes__vrf=ip_range.vrf, prefixes__prefix__net_contains_or_equals=ip_range.end_address)
+                )
+        if ip_addresses := [o for o in objects if o._meta.model_name == "ipaddress"]:
+            for ip_address in ip_addresses:
+                # prefixes where passed IP is within prefix
+                filtering |= models.Q(prefixes__vrf=ip_address.vrf, prefixes__prefix__net_contains=ip_address.address)
+                # ranges where passed IP is within range
+                filtering |= models.Q(ip_ranges__vrf=ip_address.vrf, ip_ranges__start_address__lte=ip_address.address, ip_ranges__end_address__gte=ip_address.address)
+
+        if other := [o for o in objects if o._meta.model_name not in ("prefix", "iprange", "ipaddress")]:
+            dev_addresses = []
+            for obj in other:
+                try:
+                    dev_addresses += get_device_ipaddresses(obj)
+                except Exception as e:
+                    raise TypeError(f"Cannot test if {self.__class__} is related to {obj}") from e
+
+            for dev_address in dev_addresses:
+                # prefixes where passed IP is within prefix
+                filtering |= models.Q(prefixes__vrf=dev_address.vrf, prefixes__prefix__net_contains=dev_address.address)
+                # ranges where passed IP is within range
+                filtering |= models.Q(ip_ranges__vrf=dev_address.vrf, ip_ranges__start_address__lte=dev_address.address, ip_ranges__end_address__gte=dev_address.address)
 
         return self.filter(filtering).distinct()
 

--- a/netbox_data_flows/templates/netbox_data_flows/related_dataflow_tab.html
+++ b/netbox_data_flows/templates/netbox_data_flows/related_dataflow_tab.html
@@ -1,0 +1,34 @@
+{% extends 'generic/object.html' %}
+{% load helpers %}
+{% load i18n %}
+{% load perms %}
+{% load render_table from django_tables2 %}
+
+{% block content %}
+  <div class="row">
+    <div class="col col-md-12">
+      <div class="card">
+        <h5 class="card-header">{% trans "Object Aliases" %}</h5>
+        {% render_table related_aliases_table %}
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col col-md-12">
+      <div class="card">
+        <h5 class="card-header">{% trans "Source in Data Flows" %}</h5>
+        {% render_table related_dataflow_sources_table %}
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col col-md-12">
+      <div class="card">
+        <h5 class="card-header">{% trans "Destination in Data Flows" %}</h5>
+        {% render_table related_dataflow_destinations_table %}
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/netbox_data_flows/views/model_tabs.py
+++ b/netbox_data_flows/views/model_tabs.py
@@ -16,7 +16,7 @@ __all__ = tuple()
 MODELS = (Device, VirtualMachine, IPAddress, IPRange, Prefix)
 
 
-def _count_related_aliases_or_dataflows(obj):
+def _count_aliases_or_dataflows(obj):
     aliases = models.ObjectAlias.objects.contains(obj).count()
     if not aliases:
         return 0  # cannot have a dataflow without an alias
@@ -49,7 +49,7 @@ class DataFlowListTabViewBase(generic.ObjectView):
     tab = ViewTab(
         label="Data Flows",
         permission="netbox_data_flows.view_dataflow",
-        badge=_count_related_aliases_or_dataflows,
+        badge=_count_aliases_or_dataflows,
         hide_if_empty=True,
     )
 
@@ -80,11 +80,81 @@ class DataFlowListTabViewBase(generic.ObjectView):
         }
 
 
+def _count_related_aliases_or_dataflows(obj):
+    aliases = models.ObjectAlias.objects.related_to(obj).count()
+    if not aliases:
+        return 0  # cannot have a dataflow without an alias
+
+    dataflows = models.DataFlow.objects.related_sources_or_destinations(obj).count()
+    # return as string so "0" is considered non-empty
+    return str(dataflows)
+
+
+class RelatedDataFlowListTabViewBase(generic.ObjectView):
+    """Add a tab with related ObjectAlias and DataFlows to built-in models."""
+
+    def __init_subclass__(cls, /, model, **kwargs):
+        """Create a subclass associated to a NetBox model."""
+        super().__init_subclass__(**kwargs)
+
+        # map the queryset to our NetBox model
+        cls.queryset = model.objects.all()
+
+        # call the decorator to register the view
+        register_model_view(
+            model,
+            name="related-dataflows-tab",
+            path="related-dataflows",
+        )(cls)
+
+    queryset = None
+    template_name = "netbox_data_flows/related_dataflow_tab.html"
+
+    tab = ViewTab(
+        label="Related Data Flows",
+        permission="netbox_data_flows.view_dataflow",
+        badge=_count_related_aliases_or_dataflows,
+        hide_if_empty=True,
+    )
+
+    def get_extra_context(self, request, parent):
+        related_aliases_table = tables.ObjectAliasTable(
+            models.ObjectAlias.objects.annotate(
+                prefix_count=Count("prefixes", distinct=True),
+                ip_range_count=Count("ip_ranges", distinct=True),
+                ip_address_count=Count("ip_addresses", distinct=True),
+            )
+            .order_by(*models.ObjectAlias._meta.ordering)
+            .related_to(parent)
+        )
+        related_aliases_table.configure(request)
+
+        related_dataflow_sources_table = tables.DataFlowTable(models.DataFlow.objects.related_sources(parent).all())
+        related_dataflow_sources_table.configure(request)
+
+        related_dataflow_destinations_table = tables.DataFlowTable(models.DataFlow.objects.related_destinations(parent).all())
+        related_dataflow_destinations_table.configure(request)
+
+        return {
+            "related_aliases_table": related_aliases_table,
+            "related_dataflow_sources_table": related_dataflow_sources_table,
+            "related_dataflow_destinations_table": related_dataflow_destinations_table,
+        }
+
+
 for model in MODELS:
     # create a subclass of DataFlowListTabViewBase per model
     type(
         f"{model.__name__}DataFlowTabView",
         (DataFlowListTabViewBase,),
+        {},
+        model=model,
+    )
+
+    # create a subclass of RelatedDataFlowListTabViewBase per model
+    type(
+        f"{model.__name__}RelatedDataFlowTabView",
+        (RelatedDataFlowListTabViewBase,),
         {},
         model=model,
     )


### PR DESCRIPTION
This PR adds a new 'Related Data Flows' model tab. This tab shows data flows that indirectly apply to a IP address, prefix, IP range or device.

An example:
The prefix 10.0.0.0/8 is used as source of a data flow. The prefix 10.0.20.0/16 is a child prefix of 10.0.0.0/8 and not part of any data flow. This child prefix won't have a  'Data Flows' tab as it is not directly referenced in a data flow. But the data flow the 10.0.0.0/8 is part of will be shown in a 'Related Data Flows' tab as those data flows implicitly apply to this child prefix.

So whenever there is a larger IP prefix or IP range that contains the currently viewed address, prefix, range or device, the data flows they are part of will be shown inside a 'Related Data Flows' tab.

This can be useful to identify all data flows that a apply to a object. Not just those applied directly. The idea for a 'Related Data Flows' tab came from the 'Related IPs' tab that is already part of NetBox.

I'm looking forward to your thoughts on this.