### PR TITLE
Overwrite the max NetBox version when testing a specific version

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -72,6 +72,12 @@ jobs:
         with:
           path: netbox-data-flows
 
+      - name: Overwrite maximum NetBox version
+        working-directory: netbox-data-flows
+        if: ${{ inputs.netbox_version }}
+        run: |
+          sed -i '/max_version =/d' netbox_data_flows/__init__.py
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Edit the plugin's max_version in the CI when testing against a specifically requested NetBox version that may be outside of that range.

Useful to manually test against new beta releases.
