### PR TITLE
Release v1.5.2 - Compatibility with NetBox v4.6.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Instructions to install, configure, update or uninstall the plugin can be found 
 
 | netbox version | netbox-data-flows version     |
 | -------------- | ----------------------------- |
+| >= 4.6.0       | >= v1.5.2                     |
 | >= 4.5.0       | >= v1.4.1                     |
 | >= 4.4.0       | >= v1.2.1, < v1.5.0           |
 | >= 4.3.0       | >= v1.1.1, < v1.5.0           |

--- a/docs/installation-configuration.md
+++ b/docs/installation-configuration.md
@@ -10,6 +10,7 @@ Once installed, go to the [quick start guide](quick-start.md) to discover how to
 
 | netbox version | netbox-data-flows version     |
 | -------------- | ----------------------------- |
+| >= 4.6.0       | >= v1.5.2                     |
 | >= 4.5.0       | >= v1.4.1                     |
 | >= 4.4.0       | >= v1.2.1, < v1.5.0           |
 | >= 4.3.0       | >= v1.1.1, < v1.5.0           |

--- a/netbox_data_flows/__init__.py
+++ b/netbox_data_flows/__init__.py
@@ -16,7 +16,7 @@ class DataFlowsConfig(PluginConfig):
         "application_custom_field": None,
     }
     min_version = "4.5.0"
-    max_version = "4.5.99"
+    max_version = "4.6.99"
 
 
 config = DataFlowsConfig


### PR DESCRIPTION
No obvious bug in the automated testing against NetBox v4.6.0-beta2, but a few warnings to investigate:

```
WARNINGS:
?: (staticfiles.W004) The directory '/home/runner/work/netbox-data-flows/netbox-data-flows/netbox/netbox/project-static/docs' in the STATICFILES_DIRS setting does not exist.

/home/runner/work/netbox-data-flows/netbox-data-flows/netbox/netbox/utilities/templatetags/helpers.py:403: FutureWarning: The querystring template tag is deprecated and will be removed in a future release. Use the built-in Django querystring tag instead.
```