### PR TITLE
 Fix the inherited tag lookup in NetBox 4.6.2

### DIFF
--- a/netbox_data_flows/models/dataflows.py
+++ b/netbox_data_flows/models/dataflows.py
@@ -11,6 +11,7 @@ from utilities.querysets import RestrictedQuerySet
 
 from netbox_data_flows import choices
 from netbox_data_flows.constants import DATAFLOW_PORT_MAX, DATAFLOW_PORT_MIN
+from netbox_data_flows.utils.tags import AccessibleTagsMixin
 
 from .groups import DataFlowGroup
 from .objectaliases import ObjectAlias
@@ -51,7 +52,7 @@ class DataFlowQuerySet(RestrictedQuerySet):
         return self.filter(models.Q(destinations__in=ObjectAlias.objects.contains(*objects))).distinct()
 
 
-class DataFlow(PrimaryModel):
+class DataFlow(AccessibleTagsMixin, PrimaryModel):
     """Representation of a data flow for an application."""
 
     # Inherited fields:
@@ -121,7 +122,8 @@ class DataFlow(PrimaryModel):
             return self.tags.all()
 
         return Tag.objects.filter(
-            models.Q(dataflow=self.pk) | models.Q(dataflowgroup__in=self.group.get_ancestors(include_self=True))
+            models.Q(netbox_data_flows_dataflow_tagged=self.pk)
+            | models.Q(netbox_data_flows_dataflowgroup_tagged__in=self.group.get_ancestors(include_self=True))
         ).distinct()
 
     #

--- a/netbox_data_flows/models/groups.py
+++ b/netbox_data_flows/models/groups.py
@@ -8,6 +8,7 @@ from netbox.models import NestedGroupModel
 from utilities.mptt import TreeManager, TreeQuerySet
 
 from netbox_data_flows.choices import DataFlowInheritedStatusChoices, DataFlowStatusChoices
+from netbox_data_flows.utils.tags import AccessibleTagsMixin
 
 from .applications import Application
 
@@ -26,7 +27,7 @@ class DataFlowGroupManager(models.Manager.from_queryset(DataFlowGroupQuerySet), 
     pass
 
 
-class DataFlowGroup(NestedGroupModel):
+class DataFlowGroup(AccessibleTagsMixin, NestedGroupModel):
     """Hierachical group of Data Flows."""
 
     # Inherited fields:
@@ -83,7 +84,9 @@ class DataFlowGroup(NestedGroupModel):
         if not self.pk:
             return []
 
-        return Tag.objects.filter(dataflowgroup__in=self.get_ancestors(include_self=True)).distinct()
+        return Tag.objects.filter(
+            netbox_data_flows_dataflowgroup_tagged__in=self.get_ancestors(include_self=True)
+        ).distinct()
 
     class Meta:
         ordering = (

--- a/netbox_data_flows/utils/tags.py
+++ b/netbox_data_flows/utils/tags.py
@@ -1,0 +1,47 @@
+from extras.managers import NetBoxTaggableManager
+from netbox.models.features import TagsMixin
+
+try:
+    from extras.managers import NetBoxTaggableManagerField
+except ImportError:
+    # Compatibility Netbox < 4.6.2
+    from taggit.managers import TaggableManager
+
+    class NetBoxTaggableManagerField(TaggableManager):
+        # Copied from NetBox 4.6.2 because we need the same related_name format
+
+        def contribute_to_class(self, cls, name):
+            super().contribute_to_class(cls, name)
+            if not cls._meta.abstract and self.remote_field.related_name:
+                self.remote_field.related_name = self.remote_field.related_name % {
+                    "class": cls.__name__.lower(),
+                    "app_label": cls._meta.app_label.lower(),
+                }
+
+        def deconstruct(self):
+            name, _path, args, kwargs = super().deconstruct()
+            kwargs.pop("related_name", None)
+            return name, "taggit.managers.TaggableManager", args, kwargs
+
+
+class AccessibleTagsMixin(TagsMixin):
+    """
+    Tags with accessible related_name.
+
+    Enables support for tag assignment. Assigned tags can be managed via the `tags` attribute,
+    which is a `NetBoxTaggableManager` instance. The field is a `NetBoxTaggableManagerField`,
+    which performs `%(app_label)s` / `%(class)s` interpolation on `related_name` to avoid
+    reverse-accessor collisions between same-named models in different apps (e.g. plugins).
+
+    Overwritten to keep the reverse relationship in NetBox 4.6.2.
+    """
+
+    tags = NetBoxTaggableManagerField(
+        through="extras.TaggedItem",
+        ordering=("weight", "name"),
+        manager=NetBoxTaggableManager,
+        related_name="%(app_label)s_%(class)s_tagged",
+    )
+
+    class Meta:
+        abstract = True


### PR DESCRIPTION
### Fixes: #122 

Overwrite the tag manager introduced in NetBox 4.6.2 to support inherited tags lookups for Dataflows and DataflowGroups

Tests will still be broken by #123 