### PR TITLE
Add a query count file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ recursive-include docs *.md *.png *.drawio
 exclude .editorconfig .pre-commit-config.yaml
 exclude mkdocs.yml
 exclude requirements_dev.txt requirements_docs.txt
+exclude netbox_data_flows/tests/query_counts.json

--- a/netbox_data_flows/tests/query_counts.json
+++ b/netbox_data_flows/tests/query_counts.json
@@ -1,0 +1,12 @@
+{
+  "application:api_list_objects": 14,
+  "application:list_objects_with_permission": 22,
+  "applicationrole:api_list_objects": 13,
+  "applicationrole:list_objects_with_permission": 20,
+  "dataflow:api_list_objects": 21,
+  "dataflow:list_objects_with_permission": 26,
+  "dataflowgroup:api_list_objects": 17,
+  "dataflowgroup:list_objects_with_permission": 26,
+  "objectalias:api_list_objects": 15,
+  "objectalias:list_objects_with_permission": 20
+}


### PR DESCRIPTION
### Fixes: #123

Add a query count file for the new query count tests introduced by NetBox 4.6.2.