### PR TITLE
Migrate DataFlowGroup to NestedLtreeGroupModel

### DIFF
--- a/netbox_data_flows/api/views.py
+++ b/netbox_data_flows/api/views.py
@@ -14,7 +14,7 @@ class DataFlowsRootView(APIRootView):
 
 
 class ApplicationRoleViewSet(NetBoxModelViewSet):
-    queryset = models.ApplicationRole.objects.all().annotate(
+    queryset = models.ApplicationRole.objects.annotate(
         application_count=Count("applications"),
     )
     serializer_class = serializers.ApplicationRoleSerializer
@@ -22,7 +22,7 @@ class ApplicationRoleViewSet(NetBoxModelViewSet):
 
 
 class ApplicationViewSet(NetBoxModelViewSet):
-    queryset = models.Application.objects.all().annotate(
+    queryset = models.Application.objects.annotate(
         dataflow_count=Count("dataflows", distinct=True),
     )
     serializer_class = serializers.ApplicationSerializer
@@ -30,14 +30,16 @@ class ApplicationViewSet(NetBoxModelViewSet):
 
 
 class DataFlowViewSet(NetBoxModelViewSet):
-    queryset = models.DataFlow.objects.all()
+    queryset = models.DataFlow.objects.add_inherited_status()
 
     serializer_class = serializers.DataFlowSerializer
     filterset_class = filtersets.DataFlowFilterSet
 
 
 class DataFlowGroupViewSet(NetBoxModelViewSet):
-    queryset = models.DataFlowGroup.objects.all()
+    queryset = models.DataFlowGroup.objects.add_related_count(
+        models.DataFlowGroup.objects.all(), models.DataFlow, "group", "dataflow_count", cumulative=True
+    ).add_inherited_status()
 
     serializer_class = serializers.DataFlowGroupSerializer
     filterset_class = filtersets.DataFlowGroupFilterSet

--- a/netbox_data_flows/migrations/0008_ltree_paths_conversion.py
+++ b/netbox_data_flows/migrations/0008_ltree_paths_conversion.py
@@ -1,0 +1,117 @@
+"""Replace django-mptt with PostgreSQL ltree for tenancy's hierarchical models.
+
+For each model this migration:
+
+1. Enables the PostgreSQL ltree extension (idempotent).
+2. Adds a nullable `path` LTreeField. For models that previously had
+   `MPTTMeta.order_insertion_by = ('name',)`, also adds a `sort_path` text column.
+3. Installs per-table BEFORE/AFTER triggers. For models with sort_path, the
+   trigger maintains both columns.
+4. Populates path (and sort_path where applicable) for existing rows via a
+   single recursive CTE per table.
+5. Tightens path to NOT NULL.
+6. Drops the legacy MPTT columns (lft, rght, tree_id, level).
+7. Adds a GiST index on path (descendant/ancestor lookups via `<@` / `@>`).
+   For sort_path models, also adds a btree index for ORDER BY listing.
+
+The reverse migration is lossy: it re-adds the MPTT columns empty and does not
+rebuild the tree. Forward migration is the supported direction.
+
+Copied from netbox/tenancy/migrations/0025_ltree_paths.py @v4.7.0
+"""
+
+import django.contrib.postgres.indexes
+import django.contrib.postgres.operations
+import django.db.models.deletion
+from django.db import migrations, models
+
+import netbox.models.ltree
+from utilities.ltree import InstallLtreeTriggers
+from utilities.mptt_to_ltree import assert_paths_populated_sql, populate_paths_sql
+
+MODELS = ("dataflowgroup",)
+TABLES = ("netbox_data_flows_dataflowgroup",)
+LEGACY_FIELDS = ("lft", "rght", "tree_id", "level")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("extras", "0144_customfield_status"),
+        ("netbox_data_flows", "0007_objectalias_tagged_members"),
+        ("tenancy", "0026_consolidate_unique_constraints"),
+        ("users", "0016_default_ordering_indexes"),
+    ]
+
+    operations = [
+        # Enable the ltree extension first so the migration fails fast if it is missing.
+        django.contrib.postgres.operations.CreateExtension("ltree"),
+        # Switch parent from mptt.fields.TreeForeignKey to django.db.models.ForeignKey.
+        migrations.AlterField(
+            model_name="dataflowgroup",
+            name="parent",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="children",
+                to="netbox_data_flows.dataflowgroup",
+            ),
+        ),
+        # Add path (nullable initially) on model.
+        *[
+            migrations.AddField(
+                model_name=m,
+                name="path",
+                field=netbox.models.ltree.LtreeField(blank=True, editable=False, null=True),
+            )
+            for m in MODELS
+        ],
+        # Add sort_path.
+        *[
+            migrations.AddField(
+                model_name=m,
+                name="sort_path",
+                field=models.TextField(blank=True, default="", editable=False),
+            )
+            for m in MODELS
+        ],
+        # Install triggers maintaining both path and sort_path.
+        *[InstallLtreeTriggers(t, name_column="name") for t in TABLES],
+        # Populate path and sort_path for existing rows via per-table recursive CTE.
+        migrations.RunSQL(
+            "\n".join(populate_paths_sql(t, sort_path=True) for t in TABLES),
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+        # Fail fast if any row still has NULL path (orphan FKs) before the
+        # AlterField below tries to set NOT NULL inside ALTER COLUMN.
+        migrations.RunSQL(
+            "\n".join(assert_paths_populated_sql(t) for t in TABLES),
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+        *[
+            migrations.AlterField(
+                model_name=m,
+                name="path",
+                field=netbox.models.ltree.LtreeField(blank=True, default="", editable=False),
+            )
+            for m in MODELS
+        ],
+        migrations.AlterModelOptions(
+            name="dataflowgroup",
+            options={"ordering": ("sort_path",)},
+        ),
+        # Drop legacy (tree_id, lft) indexes and the MPTT columns.
+        # migrations.RemoveIndex(model_name="dataflowgroup", name="netbox_data_flows_dataflowgroup_tree_id_faa41f90"),
+        *[migrations.RemoveField(model_name=m, name=f) for m in MODELS for f in LEGACY_FIELDS],
+        # GiST indexes on path.
+        migrations.AddIndex(
+            model_name="dataflowgroup",
+            index=django.contrib.postgres.indexes.GistIndex(fields=["path"], name="netbox_data_flows_dfg_path_gist"),
+        ),
+        # Btree indexes on sort_path for ORDER BY listing.
+        migrations.AddIndex(
+            model_name="dataflowgroup",
+            index=models.Index(fields=["sort_path"], name="netbox_data_flows_dfg_spath_ix"),
+        ),
+    ]

--- a/netbox_data_flows/models/dataflows.py
+++ b/netbox_data_flows/models/dataflows.py
@@ -1,6 +1,7 @@
 from django.contrib.postgres.fields import ArrayField
 from django.core.validators import MaxValueValidator, MinValueValidator
-from django.db import models
+from django.db import connection, models
+from django.db.models.expressions import RawSQL
 from django.urls import reverse
 from django.utils.functional import cached_property
 
@@ -63,6 +64,20 @@ class DataFlowQuerySet(RestrictedQuerySet):
             )
         ).distinct()
 
+    def add_inherited_status(self):
+        """Precompute the inherited status based on ancestors status."""
+        qn = connection.ops.quote_name
+        df_table = qn(self.model._meta.db_table)
+        group_table = qn(DataFlowGroup._meta.db_table)
+        return self.annotate(
+            _inherited_status_disabled_parent=RawSQL(
+                f"(SELECT COUNT(dfg_ancestors.id) FROM {group_table} as dfg_ancestors LEFT JOIN {group_table} "
+                f"ON {group_table}.id = {df_table}.group_id "
+                f"WHERE dfg_ancestors.status = %s AND dfg_ancestors.path @> {group_table}.path)",
+                [choices.DataFlowInheritedStatusChoices.STATUS_DISABLED],
+            )
+        )
+
 
 class DataFlow(AccessibleTagsMixin, PrimaryModel):
     """Representation of a data flow for an application."""
@@ -108,6 +123,11 @@ class DataFlow(AccessibleTagsMixin, PrimaryModel):
 
     @cached_property
     def inherited_status(self):
+        if hasattr(self, "_inherited_status_disabled_parent"):
+            if self._inherited_status_disabled_parent != 0:
+                return choices.DataFlowInheritedStatusChoices.STATUS_INHERITED_DISABLED
+            return self.status
+
         if self.status == choices.DataFlowStatusChoices.STATUS_DISABLED:
             return self.status
         elif self.group and self.group.inherited_status != choices.DataFlowInheritedStatusChoices.STATUS_ENABLED:

--- a/netbox_data_flows/models/groups.py
+++ b/netbox_data_flows/models/groups.py
@@ -1,11 +1,12 @@
+from django.contrib.postgres.indexes import GistIndex
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.urls import reverse
 from django.utils.functional import cached_property
 
 from extras.models import Tag
-from netbox.models import NestedGroupModel
-from utilities.mptt import TreeManager, TreeQuerySet
+from netbox.models import NestedLtreeGroupModel
+from netbox.models.ltree import LtreeManager, LtreeQuerySet
 
 from netbox_data_flows.choices import DataFlowInheritedStatusChoices, DataFlowStatusChoices
 from netbox_data_flows.utils.tags import AccessibleTagsMixin
@@ -15,7 +16,7 @@ from .applications import Application
 __all__ = ("DataFlowGroup",)
 
 
-class DataFlowGroupQuerySet(TreeQuerySet):
+class DataFlowGroupQuerySet(LtreeQuerySet):
     def only_disabled(self):
         return self.filter(status=DataFlowStatusChoices.STATUS_DISABLED).get_descendants(include_self=True)
 
@@ -23,11 +24,11 @@ class DataFlowGroupQuerySet(TreeQuerySet):
         return self.exclude(pk__in=self.only_disabled().only("pk"))
 
 
-class DataFlowGroupManager(models.Manager.from_queryset(DataFlowGroupQuerySet), TreeManager):
+class DataFlowGroupManager(models.Manager.from_queryset(DataFlowGroupQuerySet), LtreeManager):
     pass
 
 
-class DataFlowGroup(AccessibleTagsMixin, NestedGroupModel):
+class DataFlowGroup(AccessibleTagsMixin, NestedLtreeGroupModel):
     """Hierachical group of Data Flows."""
 
     # Inherited fields:
@@ -89,9 +90,10 @@ class DataFlowGroup(AccessibleTagsMixin, NestedGroupModel):
         ).distinct()
 
     class Meta:
-        ordering = (
-            "application",
-            "name",
+        ordering = ("sort_path",)
+        indexes = (
+            GistIndex(fields=["path"], name="netbox_data_flows_dfg_path_gist"),
+            models.Index(fields=["sort_path"], name="netbox_data_flows_dfg_spath_ix"),
         )
         constraints = (
             models.UniqueConstraint(

--- a/netbox_data_flows/models/groups.py
+++ b/netbox_data_flows/models/groups.py
@@ -23,6 +23,18 @@ class DataFlowGroupQuerySet(LtreeQuerySet):
     def only_enabled(self):
         return self.exclude(pk__in=self.only_disabled().only("pk"))
 
+    def get_descendants(self, include_self=False):
+        lookup = "descendant_or_equal" if include_self else "descendant"
+
+        path_filter = models.Q()
+        for path in self.only("path").values_list("path", flat=True):
+            path_filter |= models.Q(**{f"path__{lookup}": path})
+
+        if not path_filter:
+            return self.none()
+
+        return self.model.objects.filter(path_filter).distinct()
+
 
 class DataFlowGroupManager(models.Manager.from_queryset(DataFlowGroupQuerySet), LtreeManager):
     pass

--- a/netbox_data_flows/models/groups.py
+++ b/netbox_data_flows/models/groups.py
@@ -1,6 +1,7 @@
 from django.contrib.postgres.indexes import GistIndex
 from django.core.exceptions import ValidationError
-from django.db import models
+from django.db import connection, models
+from django.db.models.expressions import RawSQL
 from django.urls import reverse
 from django.utils.functional import cached_property
 
@@ -34,6 +35,30 @@ class DataFlowGroupQuerySet(LtreeQuerySet):
             return self.none()
 
         return self.model.objects.filter(path_filter).distinct()
+
+    def get_ancestors(self, include_self=False):
+        lookup = "ancestor_or_equal" if include_self else "ancestor"
+
+        path_filter = models.Q()
+        for path in self.only("path").values_list("path", flat=True):
+            path_filter |= models.Q(**{f"path__{lookup}": path})
+
+        if not path_filter:
+            return self.none()
+
+        return self.model.objects.filter(path_filter).distinct()
+
+    def add_inherited_status(self):
+        """Precompute the inherited status based on ancestors status."""
+        qn = connection.ops.quote_name
+        group_table = qn(self.model._meta.db_table)
+        return self.annotate(
+            _inherited_status_disabled_parent=RawSQL(
+                f"(SELECT COUNT(dfg_ancestors.id) FROM {group_table} as dfg_ancestors WHERE dfg_ancestors.status = %s "
+                f"AND dfg_ancestors.path @> {group_table}.path AND dfg_ancestors.path <> {group_table}.path)",
+                [DataFlowInheritedStatusChoices.STATUS_DISABLED],
+            )
+        )
 
 
 class DataFlowGroupManager(models.Manager.from_queryset(DataFlowGroupQuerySet), LtreeManager):
@@ -75,6 +100,11 @@ class DataFlowGroup(AccessibleTagsMixin, NestedLtreeGroupModel):
 
     @cached_property
     def inherited_status(self):
+        if hasattr(self, "_inherited_status_disabled_parent"):
+            if self._inherited_status_disabled_parent != 0:
+                return DataFlowInheritedStatusChoices.STATUS_INHERITED_DISABLED
+            return self.status
+
         if self.status == DataFlowStatusChoices.STATUS_DISABLED:
             return self.status
         elif self.get_ancestors(include_self=False).filter(status=DataFlowStatusChoices.STATUS_DISABLED).exists():

--- a/netbox_data_flows/tables/dataflows.py
+++ b/netbox_data_flows/tables/dataflows.py
@@ -26,7 +26,7 @@ class DataFlowTable(TenancyColumnsMixin, PrimaryModelTable):
     group = tables.Column(
         linkify=True,
     )
-    name = columns.MPTTColumn(
+    name = tables.Column(
         linkify=True,
     )
     status = ChoiceFieldColumn(accessor=tables.A("inherited_status_display"))

--- a/netbox_data_flows/tests/query_counts.json
+++ b/netbox_data_flows/tests/query_counts.json
@@ -3,10 +3,10 @@
   "application:list_objects_with_permission": 19,
   "applicationrole:api_list_objects": 12,
   "applicationrole:list_objects_with_permission": 17,
-  "dataflow:api_list_objects": 20,
-  "dataflow:list_objects_with_permission": 23,
+  "dataflow:api_list_objects": 18,
+  "dataflow:list_objects_with_permission": 21,
   "dataflowgroup:api_list_objects": 16,
-  "dataflowgroup:list_objects_with_permission": 23,
+  "dataflowgroup:list_objects_with_permission": 19,
   "objectalias:api_list_objects": 17,
   "objectalias:list_objects_with_permission": 19
 }

--- a/netbox_data_flows/views/dataflows.py
+++ b/netbox_data_flows/views/dataflows.py
@@ -27,7 +27,7 @@ def _get_resolved_ip_addresses(aliases):
 
 @register_model_view(models.DataFlow, "list", path="", detail=False)
 class DataFlowListView(generic.ObjectListView):
-    queryset = models.DataFlow.objects.all()
+    queryset = models.DataFlow.objects.add_inherited_status()
     table = tables.DataFlowTable
     filterset = filtersets.DataFlowFilterSet
     filterset_form = forms.DataFlowFilterForm

--- a/netbox_data_flows/views/groups.py
+++ b/netbox_data_flows/views/groups.py
@@ -1,5 +1,3 @@
-from django.db.models import Count
-
 from netbox.views import generic
 from utilities.views import register_model_view
 
@@ -18,8 +16,8 @@ __all__ = (
 
 @register_model_view(models.DataFlowGroup, "list", path="", detail=False)
 class DataFlowGroupListView(generic.ObjectListView):
-    queryset = models.DataFlowGroup.objects.annotate(
-        dataflow_count=Count("dataflows", distinct=True),
+    queryset = models.DataFlowGroup.objects.add_related_count(
+        models.DataFlowGroup.objects.all(), models.DataFlow, "group", "dataflow_count", cumulative=True
     )
     table = tables.DataFlowGroupTable
     filterset = filtersets.DataFlowGroupFilterSet
@@ -52,8 +50,8 @@ class DataFlowGroupBulkImportView(generic.BulkImportView):
 
 @register_model_view(models.DataFlowGroup, "bulk_edit", path="edit", detail=False)
 class DataFlowGroupBulkEditView(generic.BulkEditView):
-    queryset = models.DataFlowGroup.objects.annotate(
-        dataflow_count=Count("dataflows", distinct=True),
+    queryset = models.DataFlowGroup.objects.add_related_count(
+        models.DataFlowGroup.objects.all(), models.DataFlow, "group", "dataflow_count", cumulative=True
     )
     filterset = filtersets.DataFlowGroupFilterSet
     table = tables.DataFlowGroupTable
@@ -62,8 +60,8 @@ class DataFlowGroupBulkEditView(generic.BulkEditView):
 
 @register_model_view(models.DataFlowGroup, "bulk_delete", path="delete", detail=False)
 class DataFlowGroupBulkDeleteView(generic.BulkDeleteView):
-    queryset = models.DataFlowGroup.objects.annotate(
-        dataflow_count=Count("dataflows", distinct=True),
+    queryset = models.DataFlowGroup.objects.add_related_count(
+        models.DataFlowGroup.objects.all(), models.DataFlow, "group", "dataflow_count", cumulative=True
     )
     filterset = filtersets.DataFlowGroupFilterSet
     table = tables.DataFlowGroupTable

--- a/netbox_data_flows/views/groups.py
+++ b/netbox_data_flows/views/groups.py
@@ -18,7 +18,7 @@ __all__ = (
 class DataFlowGroupListView(generic.ObjectListView):
     queryset = models.DataFlowGroup.objects.add_related_count(
         models.DataFlowGroup.objects.all(), models.DataFlow, "group", "dataflow_count", cumulative=True
-    )
+    ).add_inherited_status()
     table = tables.DataFlowGroupTable
     filterset = filtersets.DataFlowGroupFilterSet
     filterset_form = forms.DataFlowGroupFilterForm
@@ -52,7 +52,7 @@ class DataFlowGroupBulkImportView(generic.BulkImportView):
 class DataFlowGroupBulkEditView(generic.BulkEditView):
     queryset = models.DataFlowGroup.objects.add_related_count(
         models.DataFlowGroup.objects.all(), models.DataFlow, "group", "dataflow_count", cumulative=True
-    )
+    ).add_inherited_status()
     filterset = filtersets.DataFlowGroupFilterSet
     table = tables.DataFlowGroupTable
     form = forms.DataFlowGroupBulkEditForm
@@ -62,6 +62,6 @@ class DataFlowGroupBulkEditView(generic.BulkEditView):
 class DataFlowGroupBulkDeleteView(generic.BulkDeleteView):
     queryset = models.DataFlowGroup.objects.add_related_count(
         models.DataFlowGroup.objects.all(), models.DataFlow, "group", "dataflow_count", cumulative=True
-    )
+    ).add_inherited_status()
     filterset = filtersets.DataFlowGroupFilterSet
     table = tables.DataFlowGroupTable


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox Data Flow!

    Please DO NOT create a public pull request for SECURITY issue. Report them
    via the security advisories:
    https://github.com/Alef-Burzmali/netbox-data-flows/security/advisories/new

    Pull requests are welcome, but if it changes models or add a non-trivial
    feature, please create an issue first to discuss and agree on an approach
    to avoid wasting your time and effort on a proposed change that we might
    not be able to accept.
-->
### Fixes: #134 

Migrate the DataFlowGroup model to the new NestedLtreeGroupModel.

Migration is based on: https://github.com/netbox-community/netbox/blob/5f06007e4c9bacc93ce17c1e645fc1143d60df3d/netbox/tenancy/migrations/0025_ltree_paths.py